### PR TITLE
Add client-side threat modeling app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# threat-modeling
+# Threat Modeling
+
+A simple client-side application for documenting potential threats on attack surfaces.
+
+## Usage
+
+1. Open `index.html` locally or via GitHub Pages.
+2. Provide your OpenAI API key in the input field.
+3. Add rows and fill in attack surfaces with descriptions.
+4. Click **Submit to AI** to classify threats. Two new columns will be filled with threat types and descriptions.
+
+### Threat Categories
+
+| id | description |
+| --- | --- |
+| `information_leakage` | Exposure of sensitive data via the surface. |
+| `data_integrity_violation` | Unauthorized modification/destruction of data. |
+| `control_plane_subversion` | Unauthorized modification/execution on the control plane. |
+| `denial_of_service` | Degradation or loss of availability. |
+| `illegitimate_use` | Abuse/misuse of resources beyond intended purpose. |
+| `entity_spoofing` | Masquerading as another principal/service. |
+| `forgery` | Fabricating messages/requests accepted as if from a trusted source. |
+| `bypassing_control` | Circumventing security controls (filtering, validation, authN/Z gates). |
+| `authorization_violation` | Access beyond assigned permissions. |
+| `trojan` | Malicious/compromised components introduced via supply chain or artifact. |
+| `guessing` | Ability to deduce or predict sensitive values (e.g., keys, tokens, identifiers). |
+| `repudiation` | Denying actions/transactions due to insufficient auditability or tamper-proof logging. |
+
+## Development
+
+The project is entirely static. Open the HTML file directly or host it with GitHub Pages.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Threat Modeling Assistant</title>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <h1>Threat Modeling Assistant</h1>
+  <p>Enter attack surfaces and descriptions. Provide your OpenAI API key then submit to classify threats.</p>
+  <input type="password" id="api-key" placeholder="OpenAI API Key" />
+  <table id="attack-table">
+    <thead>
+      <tr>
+        <th>Attack Surface</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td contenteditable="true"></td>
+        <td contenteditable="true"></td>
+      </tr>
+    </tbody>
+  </table>
+  <button id="add-row">Add Row</button>
+  <button id="submit-ai">Submit to AI</button>
+  <div id="error" class="error"></div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,100 @@
+const categories = [
+  { id: 'information_leakage', description: 'Exposure of sensitive data via the surface.' },
+  { id: 'data_integrity_violation', description: 'Unauthorized modification/destruction of data.' },
+  { id: 'control_plane_subversion', description: 'Unauthorized modification/execution on the control plane.' },
+  { id: 'denial_of_service', description: 'Degradation or loss of availability.' },
+  { id: 'illegitimate_use', description: 'Abuse/misuse of resources beyond intended purpose.' },
+  { id: 'entity_spoofing', description: 'Masquerading as another principal/service.' },
+  { id: 'forgery', description: 'Fabricating messages/requests accepted as if from a trusted source.' },
+  { id: 'bypassing_control', description: 'Circumventing security controls (filtering, validation, authN/Z gates).' },
+  { id: 'authorization_violation', description: 'Access beyond assigned permissions.' },
+  { id: 'trojan', description: 'Malicious/compromised components introduced via supply chain or artifact.' },
+  { id: 'guessing', description: 'Ability to deduce or predict sensitive values (e.g., keys, tokens, identifiers).' },
+  { id: 'repudiation', description: 'Denying actions/transactions due to insufficient auditability or tamper-proof logging.' }
+];
+
+const table = document.getElementById('attack-table');
+const addRowBtn = document.getElementById('add-row');
+const submitBtn = document.getElementById('submit-ai');
+const errorDiv = document.getElementById('error');
+
+addRowBtn.addEventListener('click', () => {
+  const row = table.tBodies[0].insertRow();
+  row.insertCell().setAttribute('contenteditable', 'true');
+  row.insertCell().setAttribute('contenteditable', 'true');
+  if (table.tHead.rows[0].cells.length > 2) {
+    row.insertCell();
+    row.insertCell();
+  }
+});
+
+submitBtn.addEventListener('click', async () => {
+  errorDiv.textContent = '';
+  const apiKey = document.getElementById('api-key').value.trim();
+  if (!apiKey) {
+    errorDiv.textContent = 'API key required.';
+    return;
+  }
+  const rows = Array.from(table.tBodies[0].rows).map((tr, idx) => ({
+    index: idx,
+    surface: tr.cells[0].innerText.trim(),
+    description: tr.cells[1].innerText.trim()
+  }));
+  const prompt = `
+You are a threat modeling assistant. For each attack surface below, identify applicable threat categories from this list and provide a brief description. Omit categories that do not apply. Respond with JSON only in the form:
+[
+  {"index":0,"threats":[{"type":"<category_id>","description":"<text>"}]}
+]
+
+Threat Categories:
+${categories.map(c => c.id + ': ' + c.description).join('\n')}
+
+Attack Surfaces:
+${rows.map(r => `#${r.index}: ${r.surface} - ${r.description}`).join('\n')}
+`;
+
+  try {
+    const res = await fetch('https://api.openai.com/v1/responses', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${apiKey}`
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o-mini',
+        input: prompt,
+        response_format: { type: 'json_object' }
+      })
+    });
+    const data = await res.json();
+    if (!res.ok) {
+      throw new Error(data.error?.message || 'Request failed');
+    }
+    let parsed;
+    try {
+      parsed = JSON.parse(data.output_text);
+    } catch (e) {
+      throw new Error('Failed to parse AI response.');
+    }
+
+    const headRow = table.tHead.rows[0];
+    if (headRow.cells.length === 2) {
+      headRow.insertCell(2).innerText = 'Threat Type';
+      headRow.insertCell(3).innerText = 'Threat Description';
+      Array.from(table.tBodies[0].rows).forEach(tr => {
+        tr.insertCell(2);
+        tr.insertCell(3);
+      });
+    }
+
+    parsed.forEach(item => {
+      const tr = table.tBodies[0].rows[item.index];
+      const types = item.threats.map(t => t.type).join('\n');
+      const descs = item.threats.map(t => t.description).join('\n');
+      tr.cells[2].innerText = types;
+      tr.cells[3].innerText = descs;
+    });
+  } catch (err) {
+    errorDiv.textContent = err.message;
+  }
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,25 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 2rem;
+}
+
+table {
+  border-collapse: collapse;
+  width: 100%;
+  margin-bottom: 1rem;
+}
+
+th, td {
+  border: 1px solid #ccc;
+  padding: 0.5rem;
+  vertical-align: top;
+}
+
+button {
+  margin-right: 0.5rem;
+}
+
+.error {
+  color: red;
+  margin-top: 1rem;
+}


### PR DESCRIPTION
## Summary
- add static HTML app for documenting attack surfaces
- integrate with OpenAI to classify threats using defined categories
- document usage and threat categories in README

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b7b5ce6cc832ea0c630faf0cdbf8a