### PR TITLE
Update OpenAI response parameter

### DIFF
--- a/script.js
+++ b/script.js
@@ -63,7 +63,7 @@ ${rows.map(r => `#${r.index}: ${r.surface} - ${r.description}`).join('\n')}
       body: JSON.stringify({
         model: 'gpt-4o-mini',
         input: prompt,
-        response_format: { type: 'json_object' }
+        text: { format: 'json' }
       })
     });
     const data = await res.json();


### PR DESCRIPTION
## Summary
- replace deprecated `response_format` with `text.format` in JavaScript fetch call

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b7ed88478832e9decf887622de288