### PR TITLE
Add Streamlit app for threat modeling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,24 @@
 # Threat Modeling
 
-A simple client-side application for documenting potential threats on attack surfaces.
+A simple application for documenting potential threats on attack surfaces.
 
-## Usage
+## Streamlit Deployment
 
-1. Open `index.html` locally or via GitHub Pages.
-2. Provide your OpenAI API key in the input field.
-3. Add rows and fill in attack surfaces with descriptions.
-4. Click **Submit to AI** to classify threats. Two new columns will be filled with threat types and descriptions.
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Run the app:
+   ```bash
+   streamlit run app.py
+   ```
+3. Provide your OpenAI API key in the input field.
+4. Add rows and fill in attack surfaces with descriptions.
+5. Click **Submit to AI** to classify threats. Two new columns will be filled with threat types and descriptions.
+
+## Static Version
+
+The original client-side version remains available. Open `index.html` locally or via GitHub Pages and follow the same usage steps above.
 
 ### Threat Categories
 
@@ -25,7 +36,3 @@ A simple client-side application for documenting potential threats on attack sur
 | `trojan` | Malicious/compromised components introduced via supply chain or artifact. |
 | `guessing` | Ability to deduce or predict sensitive values (e.g., keys, tokens, identifiers). |
 | `repudiation` | Denying actions/transactions due to insufficient auditability or tamper-proof logging. |
-
-## Development
-
-The project is entirely static. Open the HTML file directly or host it with GitHub Pages.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,97 @@
+import streamlit as st
+import pandas as pd
+import requests
+import json
+
+# Threat categories used for classification
+CATEGORIES = [
+    {"id": "information_leakage", "description": "Exposure of sensitive data via the surface."},
+    {"id": "data_integrity_violation", "description": "Unauthorized modification/destruction of data."},
+    {"id": "control_plane_subversion", "description": "Unauthorized modification/execution on the control plane."},
+    {"id": "denial_of_service", "description": "Degradation or loss of availability."},
+    {"id": "illegitimate_use", "description": "Abuse/misuse of resources beyond intended purpose."},
+    {"id": "entity_spoofing", "description": "Masquerading as another principal/service."},
+    {"id": "forgery", "description": "Fabricating messages/requests accepted as if from a trusted source."},
+    {"id": "bypassing_control", "description": "Circumventing security controls (filtering, validation, authN/Z gates)."},
+    {"id": "authorization_violation", "description": "Access beyond assigned permissions."},
+    {"id": "trojan", "description": "Malicious/compromised components introduced via supply chain or artifact."},
+    {"id": "guessing", "description": "Ability to deduce or predict sensitive values (e.g., keys, tokens, identifiers)."},
+    {"id": "repudiation", "description": "Denying actions/transactions due to insufficient auditability or tamper-proof logging."},
+]
+
+st.title("Threat Modeling Assistant")
+st.write(
+    "Enter attack surfaces and descriptions. Provide your OpenAI API key then submit to classify threats."
+)
+
+api_key = st.text_input("OpenAI API Key", type="password")
+
+# Initialize table
+if "data" not in st.session_state:
+    st.session_state.data = pd.DataFrame(
+        [{"Attack Surface": "", "Description": ""}]
+    )
+
+# Allow user to edit table dynamically
+edited = st.data_editor(
+    st.session_state.data,
+    num_rows="dynamic",
+    use_container_width=True,
+    key="data_editor",
+)
+st.session_state.data = edited
+
+if st.button("Submit to AI"):
+    if not api_key:
+        st.error("API key required.")
+    else:
+        rows = (
+            st.session_state.data[["Attack Surface", "Description"]]
+            .fillna("")
+            .to_dict(orient="records")
+        )
+        prompt = f"""
+You are a threat modeling assistant. For each attack surface below, identify applicable threat categories from this list and provide a brief description. Omit categories that do not apply. Respond with JSON only in the form:
+[
+  {{"index":0,"threats":[{{"type":"<category_id>","description":"<text>"}}]}}
+]
+
+Threat Categories:
+{chr(10).join([f"{c['id']}: {c['description']}" for c in CATEGORIES])}
+
+Attack Surfaces:
+{chr(10).join([f"#{i}: {r['Attack Surface']} - {r['Description']}" for i, r in enumerate(rows)])}
+"""
+        try:
+            response = requests.post(
+                "https://api.openai.com/v1/responses",
+                headers={
+                    "Authorization": f"Bearer {api_key}",
+                    "Content-Type": "application/json",
+                },
+                json={
+                    "model": "gpt-4o-mini",
+                    "input": prompt,
+                    "response_format": {"type": "json_object"},
+                },
+                timeout=30,
+            )
+            response.raise_for_status()
+            body = response.json()
+            parsed = json.loads(body["output"][0]["content"][0]["text"])
+
+            if "Threat Type" not in st.session_state.data.columns:
+                st.session_state.data["Threat Type"] = ""
+                st.session_state.data["Threat Description"] = ""
+
+            for item in parsed:
+                types = "\n".join(t["type"] for t in item["threats"])
+                descs = "\n".join(t["description"] for t in item["threats"])
+                st.session_state.data.at[item["index"], "Threat Type"] = types
+                st.session_state.data.at[
+                    item["index"], "Threat Description"
+                ] = descs
+
+            st.experimental_rerun()
+        except Exception as e:
+            st.error(str(e))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+pandas
+requests


### PR DESCRIPTION
## Summary
- add Streamlit UI mirroring the original attack-surface table and OpenAI classification
- document Streamlit usage and preserve static version
- specify Python dependencies for deployment

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_689b88f70e60832e835e3c5737af7900