### PR TITLE
Handle stray whitespace in OpenAI API key

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,7 +24,7 @@ st.write(
     "Enter attack surfaces and descriptions. Provide your OpenAI API key then submit to classify threats."
 )
 
-api_key = st.text_input("OpenAI API Key", type="password")
+api_key = st.text_input("OpenAI API Key", type="password").strip()
 
 # Initialize table
 if "data" not in st.session_state:


### PR DESCRIPTION
## Summary
- Strip whitespace from the provided OpenAI API key to prevent missing Authorization header errors

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689b8b9216a0832eafae48b9e857420f