### PR TITLE
feat: allow custom AI endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A simple application for documenting potential threats on attack surfaces.
    ```bash
    streamlit run app.py
    ```
-3. Provide your OpenAI API key in the input field.
+3. Provide your OpenAI API key in the input field and optionally set a custom API endpoint.
 4. Add rows and fill in attack surfaces with descriptions.
 5. Click **Submit to AI** to classify threats. Two new columns will be filled with threat types and descriptions.
 

--- a/app.py
+++ b/app.py
@@ -21,10 +21,11 @@ CATEGORIES = [
 
 st.title("Threat Modeling Assistant")
 st.write(
-    "Enter attack surfaces and descriptions. Provide your OpenAI API key then submit to classify threats."
+    "Enter attack surfaces and descriptions. Provide your OpenAI API key and optionally a custom endpoint, then submit to classify threats."
 )
 
 api_key = st.text_input("OpenAI API Key", type="password").strip()
+endpoint = st.text_input("AI API Endpoint (optional)").strip()
 
 # Initialize table
 if "data" not in st.session_state:
@@ -63,8 +64,9 @@ Attack Surfaces:
 {chr(10).join([f"#{i}: {r['Attack Surface']} - {r['Description']}" for i, r in enumerate(rows)])}
 """
         try:
+            url = endpoint or "https://api.openai.com/v1/responses"
             response = requests.post(
-                "https://api.openai.com/v1/responses",
+                url,
                 headers={
                     "Authorization": f"Bearer {api_key}",
                     "Content-Type": "application/json",


### PR DESCRIPTION
## Summary
- allow users to specify a custom AI API endpoint, defaulting to OpenAI when left blank
- document optional endpoint configuration in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689b8e9b00a8832ea905e98048bbd8aa