### PR TITLE
fix: load API key from environment

### DIFF
--- a/app.py
+++ b/app.py
@@ -2,6 +2,7 @@ import streamlit as st
 import pandas as pd
 import requests
 import json
+import os
 
 # Threat categories used for classification
 CATEGORIES = [
@@ -24,7 +25,12 @@ st.write(
     "Enter attack surfaces and descriptions. Provide your OpenAI API key then submit to classify threats."
 )
 
-api_key = st.text_input("OpenAI API Key", type="password").strip()
+default_api_key = os.environ.get("OPENAI_API_KEY", "")
+api_key = st.text_input(
+    "OpenAI API Key",
+    type="password",
+    value=default_api_key,
+).strip()
 
 # Initialize table
 if "data" not in st.session_state:


### PR DESCRIPTION
## Summary
- allow `OPENAI_API_KEY` env var to prefill API key in Streamlit UI
- ensures request includes Authorization header when key is set

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689b8e6bfa9c832eb80d43f88dbb846c