### PR TITLE
Fix duplicate API key input causing Streamlit error

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,8 +31,6 @@ api_key = st.text_input(
     type="password",
     value=default_api_key,
 ).strip()
-
-api_key = st.text_input("OpenAI API Key", type="password").strip()
 endpoint = st.text_input("AI API Endpoint (optional)").strip()
 
 # Initialize table


### PR DESCRIPTION
## Summary
- Remove second API key `st.text_input` to avoid Streamlit DuplicateElementId error

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689b914b9d8c832eb529d01b3e026a04