### PR TITLE
Fix duplicate API key input

### DIFF
--- a/app.py
+++ b/app.py
@@ -31,8 +31,6 @@ api_key = st.text_input(
     type="password",
     value=default_api_key,
 ).strip()
-
-api_key = st.text_input("OpenAI API Key", type="password").strip()
 endpoint = st.text_input("AI API Endpoint (optional)").strip()
 
 # Initialize table
@@ -105,3 +103,4 @@ Attack Surfaces:
             st.experimental_rerun()
         except Exception as e:
             st.error(str(e))
+


### PR DESCRIPTION
## Summary
- remove redundant API key input to honor default from environment
- add trailing newline to script

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689b91608bf0832e87e596ed8e04ee2a