### PR TITLE
Improve Streamlit rerun and add tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+.pytest_cache/

--- a/app.py
+++ b/app.py
@@ -132,7 +132,7 @@ def main() -> None:
         else:
             try:
                 classify_threats(api_key, base_url)
-                st.experimental_rerun()
+                st.rerun()
             except Exception as e:
                 st.error(str(e))
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,0 +1,60 @@
+import json
+import pandas as pd
+import streamlit as st
+from unittest.mock import patch
+import sys
+from types import SimpleNamespace
+from pathlib import Path
+
+# Ensure repository root is on the import path
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+# Provide a lightweight stub for litellm to avoid heavy imports during testing
+sys.modules.setdefault('litellm', SimpleNamespace(completion=lambda **kwargs: None))
+
+import app
+
+
+def test_build_prompt_contains_surfaces_and_categories():
+    rows = [{"Attack Surface": "Login", "Description": "User login"}]
+    prompt = app.build_prompt(rows)
+    assert "Login - User login" in prompt
+    assert "information_leakage" in prompt
+
+
+def test_classify_threats_populates_dataframe():
+    st.session_state.clear()
+    st.session_state.data = pd.DataFrame([
+        {"Attack Surface": "Surface A", "Description": "Desc A"},
+        {"Attack Surface": "Surface B", "Description": "Desc B"},
+    ])
+
+    mock_response = {
+        "choices": [
+            {
+                "message": {
+                    "content": json.dumps([
+                        {
+                            "index": 0,
+                            "threats": [
+                                {
+                                    "type": "denial_of_service",
+                                    "description": "Example threat",
+                                }
+                            ],
+                        },
+                        {"index": 1, "threats": []},
+                    ])
+                }
+            }
+        ]
+    }
+
+    with patch("app.litellm.completion", return_value=mock_response):
+        app.classify_threats("test-key", base_url="")
+
+    df = st.session_state.data
+    assert "Threat Type" in df.columns
+    assert df.loc[0, "Threat Type"] == "denial_of_service"
+    assert df.loc[0, "Threat Description"] == "Example threat"
+    assert df.loc[1, "Threat Type"] == ""


### PR DESCRIPTION
## Summary
- Replace deprecated `st.experimental_rerun` with `st.rerun`
- Add unit tests covering prompt generation and threat classification
- Ignore Python and pytest cache artifacts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bbbd5be30832e9f7e84a8cae24d4b