### PR TITLE
Handle object responses in classify_threats

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -62,3 +62,48 @@ def test_classify_threats_populates_dataframe():
     assert df.loc[0, "Threat Type"] == "denial_of_service"
     assert df.loc[0, "Threat Description"] == "Example threat"
     assert df.loc[1, "Threat Type"] == ""
+
+
+def test_classify_threats_handles_single_object_response():
+    """Ensure classify_threats can handle a top-level JSON object."""
+    st.session_state.clear()
+    st.session_state.data = pd.DataFrame([
+        {"Attack Surface": "Surface A", "Description": "Desc A"},
+        {"Attack Surface": "Surface B", "Description": "Desc B"},
+    ])
+
+    # Simulate a response where the model returned a single JSON object
+    mock_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content=json.dumps(
+                        {
+                            "index": 0,
+                            "threats": [
+                                {
+                                    "type": "denial_of_service",
+                                    "description": "Example threat",
+                                }
+                            ],
+                        }
+                    )
+                )
+            )
+        ]
+    )
+
+    mock_client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=lambda **kwargs: mock_response)
+        )
+    )
+
+    with patch("app.OpenAI", return_value=mock_client):
+        app.classify_threats("test-key", base_url="")
+
+    df = st.session_state.data
+    assert df.loc[0, "Threat Type"] == "denial_of_service"
+    assert df.loc[0, "Threat Description"] == "Example threat"
+    # Second row should remain empty since no item was provided
+    assert df.loc[1, "Threat Type"] == ""


### PR DESCRIPTION
## Summary
- normalize OpenAI responses in `classify_threats` to accept single objects or wrapped structures
- add regression test for single-object response

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689bc8eac31c832ebf42b014c2396b52