### PR TITLE
refactor: remove UI and table elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,35 @@
 # Threat Modeling
 
-A simple application for documenting potential threats on attack surfaces.
+Utilities for documenting potential threats on attack surfaces.
 
-## Streamlit Deployment
+## Usage
 
 1. Install dependencies:
    ```bash
    pip install -r requirements.txt
    ```
-2. Run the app:
-   ```bash
-   streamlit run app.py
+2. Import the module and call `classify_threats` with a DataFrame of attack surfaces:
+   ```python
+   import pandas as pd
+   import app
+
+   df = pd.DataFrame([
+       {"Attack Surface": "Login", "Description": "User login"}
+   ])
+   results = app.classify_threats(df, api_key="sk-...", base_url="https://llm.labs.blackduck.com/v1")
    ```
-3. Provide your OpenAI API key in the input field and optionally set a custom API base URL.
-   You can also export the variables directly:
-   ```bash
-   export OPENAI_API_KEY="sk-..."
-   export OPENAI_BASE_URL="https://llm.labs.blackduck.com/v1"
-   ```
-4. Add rows and fill in attack surfaces with descriptions.
-5. Click **Submit to AI** to classify threats. Two new columns will be filled with threat types and descriptions.
 
 ### Threat Categories
 
-| id | description |
-| --- | --- |
-| `information_leakage` | Exposure of sensitive data via the surface. |
-| `data_integrity_violation` | Unauthorized modification/destruction of data. |
-| `control_plane_subversion` | Unauthorized modification/execution on the control plane. |
-| `denial_of_service` | Degradation or loss of availability. |
-| `illegitimate_use` | Abuse/misuse of resources beyond intended purpose. |
-| `entity_spoofing` | Masquerading as another principal/service. |
-| `forgery` | Fabricating messages/requests accepted as if from a trusted source. |
-| `bypassing_control` | Circumventing security controls (filtering, validation, authN/Z gates). |
-| `authorization_violation` | Access beyond assigned permissions. |
-| `trojan` | Malicious/compromised components introduced via supply chain or artifact. |
-| `guessing` | Ability to deduce or predict sensitive values (e.g., keys, tokens, identifiers). |
-| `repudiation` | Denying actions/transactions due to insufficient auditability or tamper-proof logging. |
+- `information_leakage` – Exposure of sensitive data via the surface.
+- `data_integrity_violation` – Unauthorized modification/destruction of data.
+- `control_plane_subversion` – Unauthorized modification/execution on the control plane.
+- `denial_of_service` – Degradation or loss of availability.
+- `illegitimate_use` – Abuse/misuse of resources beyond intended purpose.
+- `entity_spoofing` – Masquerading as another principal/service.
+- `forgery` – Fabricating messages/requests accepted as if from a trusted source.
+- `bypassing_control` – Circumventing security controls (filtering, validation, authN/Z gates).
+- `authorization_violation` – Access beyond assigned permissions.
+- `trojan` – Malicious/compromised components introduced via supply chain or artifact.
+- `guessing` – Ability to deduce or predict sensitive values (e.g., keys, tokens, identifiers).
+- `repudiation` – Denying actions/transactions due to insufficient auditability or tamper-proof logging.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-streamlit
 pandas
 requests
 openai

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,10 +1,13 @@
 import json
-import pandas as pd
-import streamlit as st
-from unittest.mock import patch
+from types import SimpleNamespace
+from pathlib import Path
+import json
 import sys
 from types import SimpleNamespace
 from pathlib import Path
+
+import pandas as pd
+from unittest.mock import patch
 
 # Ensure repository root is on the import path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
@@ -20,8 +23,7 @@ def test_build_prompt_contains_surfaces_and_categories():
 
 
 def test_classify_threats_populates_dataframe():
-    st.session_state.clear()
-    st.session_state.input_df = pd.DataFrame([
+    data = pd.DataFrame([
         {"Attack Surface": "Surface A", "Description": "Desc A"},
         {"Attack Surface": "Surface B", "Description": "Desc B"},
     ])
@@ -55,9 +57,8 @@ def test_classify_threats_populates_dataframe():
         )
     )
     with patch("app.OpenAI", return_value=mock_client):
-        app.classify_threats("test-key", base_url="")
+        df = app.classify_threats(data, "test-key", base_url="")
 
-    df = st.session_state.results_df
     assert len(df) == 2
     assert list(df["Attack Surface"]) == ["Surface A", "Surface B"]
     assert df.loc[0, "Threat Type"] == "denial_of_service"
@@ -67,13 +68,11 @@ def test_classify_threats_populates_dataframe():
 
 def test_classify_threats_handles_single_object_response():
     """Ensure classify_threats can handle a top-level JSON object."""
-    st.session_state.clear()
-    st.session_state.input_df = pd.DataFrame([
+    data = pd.DataFrame([
         {"Attack Surface": "Surface A", "Description": "Desc A"},
         {"Attack Surface": "Surface B", "Description": "Desc B"},
     ])
 
-    # Simulate a response where the model returned a single JSON object
     mock_response = SimpleNamespace(
         choices=[
             SimpleNamespace(
@@ -101,9 +100,8 @@ def test_classify_threats_handles_single_object_response():
     )
 
     with patch("app.OpenAI", return_value=mock_client):
-        app.classify_threats("test-key", base_url="")
+        df = app.classify_threats(data, "test-key", base_url="")
 
-    df = st.session_state.results_df
     assert len(df) == 2
     assert df.loc[0, "Threat Type"] == "denial_of_service"
     assert df.loc[0, "Threat Description"] == "Example threat"
@@ -111,8 +109,7 @@ def test_classify_threats_handles_single_object_response():
 
 
 def test_classify_threats_multiple_threats_create_multiple_rows():
-    st.session_state.clear()
-    st.session_state.input_df = pd.DataFrame([
+    data = pd.DataFrame([
         {"Attack Surface": "Surface A", "Description": "Desc A"},
     ])
 
@@ -148,64 +145,9 @@ def test_classify_threats_multiple_threats_create_multiple_rows():
         )
     )
     with patch("app.OpenAI", return_value=mock_client):
-        app.classify_threats("test-key", base_url="")
+        df = app.classify_threats(data, "test-key", base_url="")
 
-    df = st.session_state.results_df
     assert len(df) == 2
     assert all(df["Attack Surface"] == "Surface A")
     assert set(df["Threat Type"]) == {"denial_of_service", "trojan"}
 
-
-def test_edit_table_persists_edits_via_on_change():
-    """Edits in the table should sync to session_state via on_change."""
-    st.session_state.clear()
-    st.session_state.input_df = pd.DataFrame([
-        {"Attack Surface": "", "Description": ""}
-    ])
-
-    updated_df = pd.DataFrame([
-        {"Attack Surface": "Surface X", "Description": "Desc X"}
-    ])
-
-    def fake_data_editor(*args, **kwargs):
-        # Ensure on_change callback is provided
-        callback = kwargs.get("on_change")
-        assert callable(callback)
-        # Simulate user edit by setting widget value and invoking callback
-        # Streamlit stores the edited value as a ``dict`` in session_state,
-        # so emulate that behaviour to ensure ``edit_table`` converts it
-        # back into a DataFrame.
-        st.session_state["data_editor"] = updated_df.to_dict(orient="index")
-        callback()
-        return updated_df
-
-    with patch("app.st.data_editor", side_effect=fake_data_editor):
-        app.edit_table()
-
-    assert st.session_state.input_df.equals(updated_df)
-
-
-def test_edit_table_handles_data_state_without_input_df():
-    """edit_table should fall back to ``data`` when ``input_df`` is absent."""
-    st.session_state.clear()
-    st.session_state.data = pd.DataFrame([
-        {"Attack Surface": "", "Description": ""}
-    ])
-
-    updated_df = pd.DataFrame([
-        {"Attack Surface": "Surface Y", "Description": "Desc Y"}
-    ])
-
-    def fake_data_editor(*args, **kwargs):
-        callback = kwargs.get("on_change")
-        assert callable(callback)
-        # Directly store DataFrame to simulate editor returning DataFrame
-        st.session_state["data_editor"] = updated_df
-        callback()
-        return updated_df
-
-    with patch("app.st.data_editor", side_effect=fake_data_editor):
-        app.edit_table()
-
-    assert "input_df" not in st.session_state
-    assert st.session_state.data.equals(updated_df)


### PR DESCRIPTION
## Summary
- remove streamlit interface and table-based UI
- expose `classify_threats` as a pure utility function
- update docs and tests accordingly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689c055c6ffc832e8c3ce34788dca5c3