### PR TITLE
Add Streamlit attack surface editor

### DIFF
--- a/app.py
+++ b/app.py
@@ -36,19 +36,6 @@ def format_attack_surfaces(rows: list[dict]) -> str:
         *surface_rows,
     ])
 
-
-def collect_attack_surfaces() -> list[dict]:
-    """Interactively collect attack surfaces and descriptions from the user."""
-    rows: list[dict] = []
-    while True:
-        surface = input("Attack Surface (leave blank to finish): ").strip()
-        if not surface:
-            break
-        description = input("Description: ").strip()
-        rows.append({"Attack Surface": surface, "Description": description})
-    return rows
-
-
 def build_prompt(rows: list[dict]) -> str:
     """Construct the prompt for the AI model."""
     categories = "\n".join(
@@ -170,3 +157,31 @@ def classify_threats(
         )
 
     return out
+
+
+def main() -> None:
+    """Run the Streamlit interface for collecting attack surfaces."""
+    import streamlit as st
+
+    st.title("Threat Modeling")
+    st.write("Enter attack surfaces and descriptions below.")
+
+    if "attack_surfaces" not in st.session_state:
+        st.session_state["attack_surfaces"] = pd.DataFrame(
+            [{"Attack Surface": "", "Description": ""}]
+        )
+
+    edited_df = st.data_editor(
+        st.session_state["attack_surfaces"],
+        num_rows="dynamic",
+        use_container_width=True,
+        key="attack_surface_editor",
+    )
+
+    st.session_state["attack_surfaces"] = edited_df
+
+    st.dataframe(edited_df, use_container_width=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pandas
 requests
 openai
+streamlit

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,7 +1,4 @@
 import json
-from types import SimpleNamespace
-from pathlib import Path
-import json
 import sys
 from types import SimpleNamespace
 from pathlib import Path
@@ -21,16 +18,6 @@ def test_build_prompt_contains_surfaces_and_categories():
     assert "| Index | Attack Surface | Description |" in prompt
     assert "| 0 | Login | User login |" in prompt
     assert "information_leakage" in prompt
-
-
-def test_collect_attack_surfaces_accepts_multiple_entries():
-    responses = ["Login", "User login", "Checkout", "Checkout flow", ""]
-    with patch("builtins.input", side_effect=responses):
-        rows = app.collect_attack_surfaces()
-    assert rows == [
-        {"Attack Surface": "Login", "Description": "User login"},
-        {"Attack Surface": "Checkout", "Description": "Checkout flow"},
-    ]
 
 
 def test_classify_threats_populates_dataframe():


### PR DESCRIPTION
## Summary
- Replace CLI attack surface input with a Streamlit interface.
- Allow users to add and edit attack surfaces and descriptions in a dynamic table.
- Add Streamlit dependency and clean up tests.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c21d60ce4832eb94d33bbbd3bed43