### PR TITLE
Add Streamlit UI for threat generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,18 @@ Utilities for documenting potential threats on attack surfaces.
    results = app.classify_threats(df, api_key="sk-...", base_url="https://llm.labs.blackduck.com/v1")
    ```
 
+## Streamlit Interface
+
+Launch a simple UI for collecting attack surfaces and generating threats:
+
+```bash
+streamlit run app.py
+```
+
+Enter attack surfaces on the first tab. Provide your API key (and optional base
+URL) then click **Generate Threats**. A read-only table of threats will appear on
+the *Threats* tab, with each threat on its own row.
+
 ### Threat Categories
 
 - `information_leakage` – Exposure of sensitive data via the surface.


### PR DESCRIPTION
## Summary
- Add Streamlit tabs with attack-surface entry and read-only threats table
- Provide button to submit attack surfaces to AI using existing classification logic
- Document how to run the Streamlit interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689c29e15f94832ea7962d3e910433f9